### PR TITLE
Fix incorrect module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/XeroAPI/xerogolang
+module github.com/lkq-carsys/xerogolang
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect


### PR DESCRIPTION
Module name didn't match the module path of the fork.
This blocks adding this module to a go module enabled project.

```
> go get github.com/lkq-carsys/xerogolang
go: github.com/lkq-carsys/xerogolang upgrade => v0.0.0-20200128110151-f886d93313b6
go get: github.com/lkq-carsys/xerogolang@v0.0.0-20200128110151-f886d93313b6: parsing go.mod:
        module declares its path as: github.com/XeroAPI/xerogolang
                but was required as: github.com/lkq-carsys/xerogolang`
```